### PR TITLE
cmake: fix readme.txt install source path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ install( FILES ${glee_BINARY_DIR}/libglee.pc DESTINATION lib/pkgconfig )
 install( DIRECTORY include/GL DESTINATION include 
          FILES_MATCHING REGEX ".*\\.h")
 
-install( FILES license.txt readme.txt 
+install( FILES license.txt ${DATA_DIR}/RELEASE/readme.txt
          DESTINATION share/doc/glee/)
 
 #


### PR DESCRIPTION
I assume you wanted DATA/RELEASE/readme.txt and not the Readme.txt from the toplevel. Fixes the `install` target in that case.